### PR TITLE
Added deep comparison on watchers and parameters to re-render the table

### DIFF
--- a/src/angular-pivot.js
+++ b/src/angular-pivot.js
@@ -12,7 +12,7 @@ module.directive('ngPivot', function(){
             var render = function(input){
                 var data = input.data || initialData || [];
                 var options = input.options || initialOptions || {};
-                element.pivotUI(data, options);
+                element.pivotUI(data, options, true);
             };
 
             //Attempt to load google charts
@@ -36,11 +36,11 @@ module.directive('ngPivot', function(){
             scope.$watch(attrs.ngPivot, function(value){
                 // Reload pivot
                 render({ data : value });
-            })
+            }, true)
             scope.$watch(attrs.ngPivotOptions, function(value){
                 // Reload pivot
                 render({ options : value });
-            })
+            }, true)
 
         }
     }


### PR DESCRIPTION
If you set the values array when the angular controller inits, everything works smoothly, but if you change the array by requesting the values from an API, the table doesn't render again.
If you request the values from an API, the pivot table doesn't render again. To fix this issue I added deep comparison in both $watch and also I added an extra parameter to the pivotUI method to render the table again.